### PR TITLE
feat: add TWZRD Agent Intel — Solana x402 trust scoring MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,11 @@ node scripts/generate-readme.mjs
 
 ## Directory
 
-No MCP servers have been submitted yet.
+### Developer Tools
+
+| Name | Description | Transport | Status |
+|------|-------------|-----------|--------|
+| [TWZRD Agent Intel](https://intel.twzrd.xyz) | Trust scoring for Solana AI agent wallets. Verify agent identity before x402 USDC micropayments. Tools: `score_agent`, `preflight_check` (free), `get_trust_receipt` (HTTP 402 paid). | streamable-http | active |
 
 ## Repository format
 

--- a/servers/developer-tools/twzrd-agent-intel/server.json
+++ b/servers/developer-tools/twzrd-agent-intel/server.json
@@ -1,0 +1,17 @@
+{
+  "slug": "twzrd-agent-intel",
+  "name": "TWZRD Agent Intel",
+  "category": "developer-tools",
+  "description": "Trust scoring for Solana AI agent wallets. Verify agent identity before x402 USDC micropayments. Tools: score_agent (trust score 0-100), preflight_check (score + stake + age + activity), get_trust_receipt (signed receipt via HTTP 402). Zero-install streamable-HTTP MCP.",
+  "homepage_url": "https://intel.twzrd.xyz",
+  "transports": [
+    "streamable-http"
+  ],
+  "tools": [
+    "score_agent",
+    "preflight_check",
+    "get_trust_receipt"
+  ],
+  "license": "proprietary",
+  "status": "active"
+}


### PR DESCRIPTION
## Summary

Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) to the `developer-tools` category.

TWZRD Agent Intel is a trust-scoring MCP server for Solana AI agent wallets. It lets agents verify the identity and on-chain history of another agent wallet before sending x402 USDC micropayments — the identity/trust layer that complements the x402 payment rail.

**Server entry**: `servers/developer-tools/twzrd-agent-intel/server.json`

### Fields

| Field | Value |
|-------|-------|
| slug | `twzrd-agent-intel` |
| category | `developer-tools` |
| transport | `streamable-http` |
| status | `active` |
| homepage | https://intel.twzrd.xyz |

### Tools

| Tool | Cost | Description |
|------|------|-------------|
| `score_agent` | Free | Trust score 0–100 for a Solana agent wallet |
| `preflight_check` | Free | Score + stake status + wallet age + activity |
| `get_trust_receipt` | HTTP 402 USDC | Signed, verifiable trust receipt |

### Zero-install MCP config

```json
{"mcpServers": {"twzrd-agent-intel": {"url": "https://intel.twzrd.xyz/mcp"}}}
```

### Notes

- No `repository_url` field (the service is proprietary/closed-source)
- README was updated manually since `node scripts/generate-readme.mjs` can't be run in this environment — the table entry follows the same format the script would generate
- Server is live and reachable at https://intel.twzrd.xyz