### PR TITLE
Add ShotAPI - screenshot and render MCP server

### DIFF
--- a/servers/browser-automation/shotapi/server.json
+++ b/servers/browser-automation/shotapi/server.json
@@ -1,0 +1,23 @@
+{
+  "slug": "shotapi",
+  "name": "ShotAPI",
+  "category": "browser-automation",
+  "description": "Screenshot and render any URL or HTML via one REST API call - MCP server for AI agents to see the web.",
+  "homepage_url": "https://shotapi.net",
+  "repository_url": "https://github.com/smallhandsome/shotapi-mcp-server",
+  "package_url": "",
+  "transports": [
+    "stdio",
+    "streamable-http"
+  ],
+  "tools": [
+    "screenshot",
+    "render"
+  ],
+  "license": "MIT",
+  "provider": {
+    "name": "ShotAPI",
+    "url": "https://shotapi.net"
+  },
+  "status": "active"
+}


### PR DESCRIPTION
## ShotAPI — Screenshot & Render MCP Server

Pixel-perfect screenshots and HTML rendering via one REST API call. MCP server for AI agents to see the web.

- **Tools**: `screenshot`, `render`
- **Transports**: stdio, streamable-http
- **Free tier**: 100 requests/month, no credit card required
- **Homepage**: https://shotapi.net
- **Repository**: https://github.com/smallhandsome/shotapi-mcp-server

### What it does

Turn any URL or raw HTML into screenshots (PNG/JPEG/WebP/PDF), render HTML to images, extract metadata & OG tags, create visual diffs, batch processing, and device mockups.

### Why it's useful

AI agents using Claude, Cursor, or other MCP clients can now capture and render web pages without deploying browser infrastructure. One POST request, get your image back in under 2 seconds.

Just launched on Product Hunt today! https://www.producthunt.com/posts/shotapi

Entry follows the `server.json` schema and is placed under `browser-automation` category.