### PR TITLE
feat: add The Stall — 202 x402 pay-per-call data tools on Base (v4.56.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,11 @@ node scripts/generate-readme.mjs
 
 ## Directory
 
-No MCP servers have been submitted yet.
+### Data
+
+| Server | Description | Transport | Links |
+|---|---|---|---|
+| The Stall | 191 pay-per-call data tools via x402 on Base — stocks, crypto/DeFi, macro, SEC filings, compliance, global news, social momentum. No API keys. | streamable-http | [Homepage](https://the-stall.intuitek.ai)<br>[GitHub](https://github.com/thebrierfox/the-stall) |
 
 ## Repository format
 

--- a/servers/data/the-stall/server.json
+++ b/servers/data/the-stall/server.json
@@ -1,0 +1,16 @@
+{
+  "slug": "the-stall",
+  "name": "The Stall",
+  "category": "data",
+  "description": "191 pay-per-call data tools via x402 on Base — stocks, crypto/DeFi, macro, SEC filings, compliance, global news, social momentum. No API keys.",
+  "homepage_url": "https://the-stall.intuitek.ai",
+  "repository_url": "https://github.com/thebrierfox/the-stall",
+  "transports": ["streamable-http"],
+  "tools": [
+    "us-stock-price", "crypto-fiat-price", "forex-rates", "options-chain",
+    "defi-yields", "sec-filing-intel", "insider-trades", "global-news-intel",
+    "social-momentum", "polymarket-intel", "sanctions-screening", "wallet-screener"
+  ],
+  "license": "MIT",
+  "status": "active"
+}


### PR DESCRIPTION
## Server Submission

**Server Name:** The Stall  
**Category:** data  
**Homepage:** https://the-stall.intuitek.ai  
**GitHub:** https://github.com/thebrierfox/the-stall  

## What it does

The Stall is an MCP server with 198 pay-per-call data capabilities using x402 micropayments on Base mainnet. No API keys or subscriptions — agents pay USDC per call.

**Coverage areas:**
- Financial: US/EU/JP/AU/KR stocks, options chains, earnings, dividend calendar, hedge fund 13F filings, insider trades
- Crypto/DeFi: DEX quotes, DeFiLlama protocol data, funding rates, stablecoin watch, Polymarket prediction markets
- Macro: FOMC tracker, Treasury yields, economic calendar, IMF country outlook
- Regulatory: SEC EDGAR filings, FEC donor intel, congressional trades, FDA recall watch
- Compliance: Sanctions screening, wallet screening, CVE intel
- News/Research: GDELT global news synthesis, Reddit/HN social momentum, arXiv search

**Price range:** $0.001 – $0.35 per call  
**Transport:** Streamable HTTP  
**Network:** Base mainnet (USDC)

## Checklist

- [x] `server.json` added to `servers/data/the-stall/`
- [x] `node scripts/validate-catalog.mjs` passes (1 entry validated)
- [x] `node scripts/generate-readme.mjs` run and README updated
- [x] Service is publicly reachable (health: https://the-stall.intuitek.ai/health)
- [x] Repository is public: https://github.com/thebrierfox/the-stall
- [x] Entry in correct category (data)