### PR TITLE
Add AccInt MCP server entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ node scripts/generate-readme.mjs
 | The Stall | 191 pay-per-call data tools via x402 on Base — stocks, crypto/DeFi, macro, SEC filings, compliance, global news, social momentum. No API keys. | streamable-http | [Homepage](https://the-stall.intuitek.ai)<br>[GitHub](https://github.com/thebrierfox/the-stall) |
 | Xquik MCP Server | MCP server for exploring Xquik's X data API and running source-backed X data workflows. | streamable-http | [Homepage](https://docs.xquik.com/mcp/overview)<br>[GitHub](https://github.com/Xquik-dev/x-twitter-scraper) |
 
+### Knowledge
+
+| Server | Description | Transport | Links |
+|---|---|---|---|
+| AccInt | Local-first Work Model and MCP server for coding-agent memory across Claude Code, OpenCode, Codex, and Cursor. Shares a SQLite memory substrate and feeds verified outcomes back into future retrieval. | stdio | [Homepage](https://accint.xyz/)<br>[GitHub](https://github.com/maxbaluev/accreted-intelligence) |
+
 ## Repository format
 
 - `CONTRIBUTING.md` explains the review policy.

--- a/servers/knowledge/accint/server.json
+++ b/servers/knowledge/accint/server.json
@@ -1,0 +1,17 @@
+{
+  "slug": "accint",
+  "name": "AccInt",
+  "category": "knowledge",
+  "description": "Local-first Work Model and MCP server for coding-agent memory across Claude Code, OpenCode, Codex, and Cursor. Shares a SQLite memory substrate and feeds verified outcomes back into future retrieval.",
+  "homepage_url": "https://accint.xyz/",
+  "repository_url": "https://github.com/maxbaluev/accreted-intelligence",
+  "transports": [
+    "stdio"
+  ],
+  "tools": [
+    "acc_retrieve",
+    "acc_act"
+  ],
+  "license": "Unspecified public glue / private core",
+  "status": "active"
+}


### PR DESCRIPTION
## What this adds

Adds AccInt as a `knowledge` MCP server entry, with generated README output.

AccInt is a local-first Work Model and MCP server for coding-agent memory across Claude Code, OpenCode, Codex, and Cursor. The entry lists the public homepage and GitHub repository, `stdio` transport, and the exposed `acc_retrieve` / `acc_act` tools.

## Notes for maintainers

The `license` metadata is intentionally written as `Unspecified public glue / private core` to avoid overstating the public/private boundary documented by the project.

## Validation

- `node scripts/validate-catalog.mjs`
- `node scripts/generate-readme.mjs`
- `git diff --check`
- Checked `https://accint.xyz/` and `https://github.com/maxbaluev/accreted-intelligence` return HTTP 200
