### PR TITLE
Add Agentage Memory (remote MCP server)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ node scripts/generate-readme.mjs
 | Server | Description | Transport | Links |
 |---|---|---|---|
 | AccInt | Local-first Work Model and MCP server for coding-agent memory across Claude Code, OpenCode, Codex, and Cursor. Shares a SQLite memory substrate and feeds verified outcomes back into future retrieval. | stdio | [Homepage](https://accint.xyz/)<br>[GitHub](https://github.com/maxbaluev/accreted-intelligence) |
+| Agentage Memory | Shared memory layer for every AI - one markdown memory Claude, Cursor, and ChatGPT read and write over a remote MCP endpoint, mirrored locally as plain .md you own and can export anytime. Remote Streamable HTTP with OAuth 2.1 + PKCE + DCR. | streamable-http | [Homepage](https://agentage.io)<br>[Package](https://memory.agentage.io/mcp) |
 
 ## Repository format
 

--- a/servers/knowledge/agentage-memory/server.json
+++ b/servers/knowledge/agentage-memory/server.json
@@ -1,0 +1,25 @@
+{
+  "slug": "agentage-memory",
+  "name": "Agentage Memory",
+  "category": "knowledge",
+  "description": "Shared memory layer for every AI - one markdown memory Claude, Cursor, and ChatGPT read and write over a remote MCP endpoint, mirrored locally as plain .md you own and can export anytime. Remote Streamable HTTP with OAuth 2.1 + PKCE + DCR.",
+  "homepage_url": "https://agentage.io",
+  "package_url": "https://memory.agentage.io/mcp",
+  "transports": [
+    "streamable-http"
+  ],
+  "tools": [
+    "memory__search",
+    "memory__read",
+    "memory__write",
+    "memory__edit",
+    "memory__list",
+    "memory__delete"
+  ],
+  "license": "Proprietary (hosted service; private source)",
+  "provider": {
+    "name": "Agentage",
+    "url": "https://agentage.io"
+  },
+  "status": "active"
+}


### PR DESCRIPTION
Adds **Agentage Memory**, a remote MCP server (Streamable HTTP) that gives every AI tool one shared markdown memory you own.

- **Endpoint:** `https://memory.agentage.io/mcp`
- **Auth:** OAuth 2.1 + PKCE + Dynamic Client Registration (no API key)
- **Website:** https://agentage.io
- **Documentation:** https://agentage.io/blog/mcp-endpoint-is-live
- **Official MCP registry:** `io.agentage/memory`

**Tools (6):** `memory__search`, `memory__read`, `memory__write`, `memory__edit`, `memory__list`, `memory__delete` — one markdown memory that Claude, Cursor, and ChatGPT all read and write, mirrored locally as plain `.md` you can export anytime.

Happy to adjust placement/format to match this repo's conventions.
