### PR TITLE
Add ax observability MCP entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ node scripts/generate-readme.mjs
 | AccInt | Local-first Work Model and MCP server for coding-agent memory across Claude Code, OpenCode, Codex, and Cursor. Shares a SQLite memory substrate and feeds verified outcomes back into future retrieval. | stdio | [Homepage](https://accint.xyz/)<br>[GitHub](https://github.com/maxbaluev/accreted-intelligence) |
 | Agentage Memory | Shared memory layer for every AI - one markdown memory Claude, Cursor, and ChatGPT read and write over a remote MCP endpoint, mirrored locally as plain .md you own and can export anytime. Remote Streamable HTTP with OAuth 2.1 + PKCE + DCR. | streamable-http | [Homepage](https://agentage.io)<br>[Package](https://memory.agentage.io/mcp) |
 
+### Observability
+
+| Server | Description | Transport | Links |
+|---|---|---|---|
+| ax | Local-first transcript and telemetry graph for AI coding agents, with read-only MCP queries for sessions, tool use, skills, costs, and dispatch/routing analytics. | stdio | [Homepage](https://github.com/Necmttn/ax)<br>[GitHub](https://github.com/Necmttn/ax) |
+
 ## Repository format
 
 - `CONTRIBUTING.md` explains the review policy.

--- a/servers/observability/ax/server.json
+++ b/servers/observability/ax/server.json
@@ -1,0 +1,23 @@
+{
+  "slug": "ax",
+  "name": "ax",
+  "category": "observability",
+  "description": "Local-first transcript and telemetry graph for AI coding agents, with read-only MCP queries for sessions, tool use, skills, costs, and dispatch/routing analytics.",
+  "homepage_url": "https://github.com/Necmttn/ax",
+  "repository_url": "https://github.com/Necmttn/ax",
+  "transports": [
+    "stdio"
+  ],
+  "tools": [
+    "recall",
+    "sessions_around",
+    "session_show",
+    "skills_weighted",
+    "cost_models",
+    "cost_split",
+    "cost_routability",
+    "dispatches"
+  ],
+  "license": "AGPL-3.0-only",
+  "status": "active"
+}


### PR DESCRIPTION
## Submission checklist

- [x] I added or updated exactly one MCP server entry under `servers/<category>/<slug>/`.
- [x] The entry has a stable public URL.
- [x] The entry category matches its folder.
- [x] I ran `node scripts/validate-catalog.mjs`.
- [x] I ran `node scripts/generate-readme.mjs`.
- [x] I confirmed `README.md` is generated and committed if it changed.

## What this adds

Adds ax under `observability`: a local-first transcript and telemetry graph for AI coding agents, exposed through read-only stdio MCP queries.

## Notes for maintainers

Checks:
- `node scripts/validate-catalog.mjs`
- `node scripts/generate-readme.mjs`
- `git diff --check`
- ax repository link check returned 200
- `apps/axctl/bin/axctl mcp --help`
- `bun test apps/axctl/src/mcp/server.smoke.test.ts --path-ignore-patterns='apps/studio-desktop/**'`
- Subagent fit/spec review passed
- Subagent copy/quality review passed

---

_Generated with [ax](https://github.com/Necmttn/ax)._
