### PR TITLE
Add BuyWhere MCP server — real-time product search across 15+ SG/SEA merchants

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ node scripts/generate-readme.mjs
 
 | Server | Description | Transport | Links |
 |---|---|---|---|
+| BuyWhere | Real-time product search and price comparison across 15+ Singapore/SEA merchants (11M+ products). REST API + MCP server for AI agents. | stdio, streamable-http | [Homepage](https://buywhere.ai)<br>[GitHub](https://github.com/BuyWhere/buywhere-mcp)<br>[Package](https://www.npmjs.com/package/@buywhere/mcp-server) |
 | The Stall | 191 pay-per-call data tools via x402 on Base — stocks, crypto/DeFi, macro, SEC filings, compliance, global news, social momentum. No API keys. | streamable-http | [Homepage](https://the-stall.intuitek.ai)<br>[GitHub](https://github.com/thebrierfox/the-stall) |
 | Xquik MCP Server | MCP server for exploring Xquik's X data API and running source-backed X data workflows. | streamable-http | [Homepage](https://docs.xquik.com/mcp/overview)<br>[GitHub](https://github.com/Xquik-dev/x-twitter-scraper) |
 

--- a/servers/data/buywhere-mcp/server.json
+++ b/servers/data/buywhere-mcp/server.json
@@ -1,0 +1,13 @@
+{
+  "slug": "buywhere-mcp",
+  "name": "BuyWhere",
+  "category": "data",
+  "description": "Real-time product search and price comparison across 15+ Singapore/SEA merchants (11M+ products). REST API + MCP server for AI agents.",
+  "homepage_url": "https://buywhere.ai",
+  "repository_url": "https://github.com/BuyWhere/buywhere-mcp",
+  "package_url": "https://www.npmjs.com/package/@buywhere/mcp-server",
+  "transports": ["stdio", "streamable-http"],
+  "tools": ["search_products", "get_product", "find_best_price", "get_deals", "browse_categories"],
+  "license": "MIT",
+  "status": "active"
+}


### PR DESCRIPTION
## Summary

Adds BuyWhere to the data category. BuyWhere provides real-time product search and price comparison across 15+ Singapore/SEA merchants (11M+ products) via an MCP server and REST API.

## What it does

- `search_products` — full-text product search across merchants
- `get_product` — product details by ID
- `find_best_price` — cross-merchant price comparison
- `get_deals` — active deals and discounts
- `browse_categories` — category browsing

## Key facts

- **11M+ products** across Lazada, Shopee, Amazon SG, FairPrice, Cold Storage, Harvey Norman, etc.
- **2,000+ weekly npm downloads** (`@buywhere/mcp-server`)
- **Transports:** stdio + streamable-http
- **License:** MIT
- **Live:** https://api.buywhere.ai/mcp

Resolves #6