### PR TITLE
Add AgentServices — x402-paid crypto/financial data MCP server (37 tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ node scripts/generate-readme.mjs
 
 | Server | Description | Transport | Links |
 |---|---|---|---|
+| AgentServices | 37 MCP tools serving 54 x402-paid crypto/financial market data endpoints on Base — spot prices, OHLCV, on-chain metrics, FX, and bundled research synthesis for AI agents. | streamable-http | [Homepage](https://agentservices.to)<br>[GitHub](https://github.com/vbkotecha/aiservices-api) |
 | BuyWhere | Real-time product search and price comparison across 15+ Singapore/SEA merchants (11M+ products). REST API + MCP server for AI agents. | stdio, streamable-http | [Homepage](https://buywhere.ai)<br>[GitHub](https://github.com/BuyWhere/buywhere-mcp)<br>[Package](https://www.npmjs.com/package/@buywhere/mcp-server) |
 | The Stall | 191 pay-per-call data tools via x402 on Base — stocks, crypto/DeFi, macro, SEC filings, compliance, global news, social momentum. No API keys. | streamable-http | [Homepage](https://the-stall.intuitek.ai)<br>[GitHub](https://github.com/thebrierfox/the-stall) |
 | Xquik MCP Server | MCP server for exploring Xquik's X data API and running source-backed X data workflows. | streamable-http | [Homepage](https://docs.xquik.com/mcp/overview)<br>[GitHub](https://github.com/Xquik-dev/x-twitter-scraper) |

--- a/repositories.yaml
+++ b/repositories.yaml
@@ -1,0 +1,5 @@
+{
+  "message": "Not Found",
+  "documentation_url": "https://docs.github.com/rest/repos/contents#get-repository-content",
+  "status": "404"
+}

--- a/servers/data/agentservices/server.json
+++ b/servers/data/agentservices/server.json
@@ -1,0 +1,16 @@
+{
+  "slug": "agentservices",
+  "name": "AgentServices",
+  "category": "data",
+  "description": "37 MCP tools serving 54 x402-paid crypto/financial market data endpoints on Base — spot prices, OHLCV, on-chain metrics, FX, and bundled research synthesis for AI agents.",
+  "homepage_url": "https://agentservices.to",
+  "repository_url": "https://github.com/vbkotecha/aiservices-api",
+  "transports": ["streamable-http"],
+  "tools": [
+    "crypto-spot-prices", "ohlcv-candles", "onchain-metrics", "fx-rates",
+    "market-depth", "token-info", "defi-pool-data", "gas-tracker",
+    "exchange-rates", "historical-prices", "market-cap", "trading-volume"
+  ],
+  "license": "MIT",
+  "status": "active"
+}


### PR DESCRIPTION
## Submission checklist

- [x] Added one MCP server entry under `servers/data/agentservices/`.
- [x] Entry has a stable public URL.
- [x] Entry category matches its folder.
- [x] Ran validator and README generator.

## What this adds

Production x402-paid MCP server providing crypto/financial market data to AI agents. 37 MCP tools across 54 endpoints, settled via USDC on Base using the x402 protocol.

- Live MCP server: `https://agentservices.to/mcp`
- Health check: `https://agentservices.to/health`
- Official MCP Registry: `to.agentservices/agentservices` (v5.3.0)
- Transport: streamable-http
- License: MIT