### PR TITLE
Add Most Recommended Books MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ node scripts/generate-readme.mjs
 |---|---|---|---|
 | AccInt | Local-first Work Model and MCP server for coding-agent memory across Claude Code, OpenCode, Codex, and Cursor. Shares a SQLite memory substrate and feeds verified outcomes back into future retrieval. | stdio | [Homepage](https://accint.xyz/)<br>[GitHub](https://github.com/maxbaluev/accreted-intelligence) |
 | Agentage Memory | Shared memory layer for every AI - one markdown memory Claude, Cursor, and ChatGPT read and write over a remote MCP endpoint, mirrored locally as plain .md you own and can export anytime. Remote Streamable HTTP with OAuth 2.1 + PKCE + DCR. | streamable-http | [Homepage](https://agentage.io)<br>[Package](https://memory.agentage.io/mcp) |
+| Most Recommended Books | Read-only Streamable HTTP MCP server for verified book recommendations, reading lists, series reading orders, consensus best-of lists, and summaries with original sources. | streamable-http | [Homepage](https://mostrecommendedbooks.com)<br>[GitHub](https://github.com/richardreeze/mrb-api)<br>[Package](https://mostrecommendedbooks.com/api/mcp) |
 
 ### Observability
 

--- a/servers/knowledge/most-recommended-books/server.json
+++ b/servers/knowledge/most-recommended-books/server.json
@@ -1,0 +1,26 @@
+{
+  "slug": "most-recommended-books",
+  "name": "Most Recommended Books",
+  "category": "knowledge",
+  "description": "Read-only Streamable HTTP MCP server for verified book recommendations, reading lists, series reading orders, consensus best-of lists, and summaries with original sources.",
+  "homepage_url": "https://mostrecommendedbooks.com",
+  "repository_url": "https://github.com/richardreeze/mrb-api",
+  "package_url": "https://mostrecommendedbooks.com/api/mcp",
+  "transports": [
+    "streamable-http"
+  ],
+  "tools": [
+    "search_books",
+    "get_person_recommendations",
+    "get_book_recommenders",
+    "get_series_reading_order",
+    "get_list",
+    "get_summary"
+  ],
+  "license": "MIT",
+  "provider": {
+    "name": "Most Recommended Books",
+    "url": "https://mostrecommendedbooks.com"
+  },
+  "status": "active"
+}


### PR DESCRIPTION
Adds a knowledge-category catalog entry for Most Recommended Books.\n\nMRB is a read-only remote Streamable HTTP MCP server for verified book recommendations, reading lists, series reading orders, consensus best-of lists, and summaries with original sources.\n\nEndpoint: https://mostrecommendedbooks.com/api/mcp\nRepo: https://github.com/richardreeze/mrb-api\nDocs: https://mostrecommendedbooks.com/developers\n\nValidation: npm run check