### PR TITLE
Add Tubask YouTube MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ node scripts/generate-readme.mjs
 |---|---|---|---|
 | AccInt | Local-first Work Model and MCP server for coding-agent memory across Claude Code, OpenCode, Codex, and Cursor. Shares a SQLite memory substrate and feeds verified outcomes back into future retrieval. | stdio | [Homepage](https://accint.xyz/)<br>[GitHub](https://github.com/maxbaluev/accreted-intelligence) |
 | Agentage Memory | Shared memory layer for every AI - one markdown memory Claude, Cursor, and ChatGPT read and write over a remote MCP endpoint, mirrored locally as plain .md you own and can export anytime. Remote Streamable HTTP with OAuth 2.1 + PKCE + DCR. | streamable-http | [Homepage](https://agentage.io)<br>[Package](https://memory.agentage.io/mcp) |
+| Tubask | Hosted YouTube MCP for Claude, Cursor, and ChatGPT — search videos, summarize talks, and pull timestamped quotes with 3 tools. Streamable HTTP with OAuth 2.0. | streamable-http | [Homepage](https://tubask.app)<br>[GitHub](https://github.com/Amorizz/tubask-mcp)<br>[Package](https://tubask.app/mcp) |
 
 ### Observability
 

--- a/servers/knowledge/tubask/server.json
+++ b/servers/knowledge/tubask/server.json
@@ -1,0 +1,23 @@
+{
+  "slug": "tubask",
+  "name": "Tubask",
+  "category": "knowledge",
+  "description": "Hosted YouTube MCP for Claude, Cursor, and ChatGPT — search videos, summarize talks, and pull timestamped quotes with 3 tools. Streamable HTTP with OAuth 2.0.",
+  "homepage_url": "https://tubask.app",
+  "repository_url": "https://github.com/Amorizz/tubask-mcp",
+  "package_url": "https://tubask.app/mcp",
+  "transports": [
+    "streamable-http"
+  ],
+  "tools": [
+    "youtube_query",
+    "summarize_video",
+    "get_transcript"
+  ],
+  "license": "MIT (public repo; hosted service)",
+  "provider": {
+    "name": "Tubask",
+    "url": "https://tubask.app"
+  },
+  "status": "active"
+}


### PR DESCRIPTION
## Summary
Adds Tubask to the knowledge category.

Hosted YouTube MCP for Claude, Cursor, and ChatGPT — 3 tools (`youtube_query`, `summarize_video`, `get_transcript`), Streamable HTTP at `https://tubask.app/mcp`, OAuth 2.0.

- Website: https://tubask.app
- GitHub: https://github.com/Amorizz/tubask-mcp
- Install: `npx @tubask/mcp init`

## Test plan
- [x] `node scripts/validate-catalog.mjs` passes
- [x] `node scripts/generate-readme.mjs` run
- [x] One server per PR

Made with [Cursor](https://cursor.com)