### PR TITLE
Add BDE Score MCP Server - AI governance scoring engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,20 @@ node scripts/generate-readme.mjs
 | The Stall | 191 pay-per-call data tools via x402 on Base — stocks, crypto/DeFi, macro, SEC filings, compliance, global news, social momentum. No API keys. | streamable-http | [Homepage](https://the-stall.intuitek.ai)<br>[GitHub](https://github.com/thebrierfox/the-stall) |
 | Xquik MCP Server | MCP server for exploring Xquik's X data API and running source-backed X data workflows. | streamable-http | [Homepage](https://docs.xquik.com/mcp/overview)<br>[GitHub](https://github.com/Xquik-dev/x-twitter-scraper) |
 
+### Developer Tools
+
+| Server | Description | Transport | Links |
+|---|---|---|---|
+| BDE Score MCP Server | AI governance scoring engine with EU AI Act Art.50 compliance. Evaluates AI system transparency, accountability and trustworthiness via MCP protocol. | stdio, sse | [Homepage](https://github.com/hbhqq9/bde-score)<br>[GitHub](https://github.com/hbhqq9/bde-score)<br>[Package](https://www.npmjs.com/package/bde-score) |
+
 ### Knowledge
 
 | Server | Description | Transport | Links |
 |---|---|---|---|
 | AccInt | Local-first Work Model and MCP server for coding-agent memory across Claude Code, OpenCode, Codex, and Cursor. Shares a SQLite memory substrate and feeds verified outcomes back into future retrieval. | stdio | [Homepage](https://accint.xyz/)<br>[GitHub](https://github.com/maxbaluev/accreted-intelligence) |
 | Agentage Memory | Shared memory layer for every AI - one markdown memory Claude, Cursor, and ChatGPT read and write over a remote MCP endpoint, mirrored locally as plain .md you own and can export anytime. Remote Streamable HTTP with OAuth 2.1 + PKCE + DCR. | streamable-http | [Homepage](https://agentage.io)<br>[Package](https://memory.agentage.io/mcp) |
-| Tubask | Hosted YouTube MCP for Claude, Cursor, and ChatGPT — search videos, summarize talks, and pull timestamped quotes with 3 tools. Streamable HTTP with OAuth 2.0. | streamable-http | [Homepage](https://tubask.app)<br>[GitHub](https://github.com/Amorizz/tubask-mcp)<br>[Package](https://tubask.app/mcp) |
 | Most Recommended Books | Read-only Streamable HTTP MCP server for verified book recommendations, reading lists, series reading orders, consensus best-of lists, and summaries with original sources. | streamable-http | [Homepage](https://mostrecommendedbooks.com)<br>[GitHub](https://github.com/richardreeze/mrb-api)<br>[Package](https://mostrecommendedbooks.com/api/mcp) |
+| Tubask | Hosted YouTube MCP for Claude, Cursor, and ChatGPT — search videos, summarize talks, and pull timestamped quotes with 3 tools. Streamable HTTP with OAuth 2.0. | streamable-http | [Homepage](https://tubask.app)<br>[GitHub](https://github.com/Amorizz/tubask-mcp)<br>[Package](https://tubask.app/mcp) |
 
 ### Observability
 

--- a/servers/developer-tools/bde-score/server.json
+++ b/servers/developer-tools/bde-score/server.json
@@ -1,0 +1,25 @@
+{
+  "slug": "bde-score",
+  "name": "BDE Score MCP Server",
+  "category": "developer-tools",
+  "description": "AI governance scoring engine with EU AI Act Art.50 compliance. Evaluates AI system transparency, accountability and trustworthiness via MCP protocol.",
+  "homepage_url": "https://github.com/hbhqq9/bde-score",
+  "repository_url": "https://github.com/hbhqq9/bde-score",
+  "package_url": "https://www.npmjs.com/package/bde-score",
+  "transports": [
+    "stdio",
+    "sse"
+  ],
+  "tools": [
+    "evaluate_system",
+    "get_transparency_score",
+    "check_art50_compliance",
+    "get_governance_report"
+  ],
+  "license": "MIT",
+  "provider": {
+    "name": "BDE Score",
+    "url": "https://github.com/hbhqq9/bde-score"
+  },
+  "status": "active"
+}


### PR DESCRIPTION
## Submission: BDE Score MCP Server

Adding BDE Score to the developer-tools category.

**What it does:** AI governance scoring engine with EU AI Act Art.50 compliance. Evaluates AI system transparency, accountability and trustworthiness via MCP protocol.

- **Repository:** https://github.com/hbhqq9/bde-score
- **NPM:** https://www.npmjs.com/package/bde-score
- **License:** MIT
- **Status:** Active
- **Transports:** stdio, sse

Validation passed (`node scripts/validate-catalog.mjs` → 9 entries OK).
README regenerated via `node scripts/generate-readme.mjs`.