### PR TITLE
Add Central Command — x402 trading MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ node scripts/generate-readme.mjs
 | Server | Description | Transport | Links |
 |---|---|---|---|
 | BuyWhere | Real-time product search and price comparison across 15+ Singapore/SEA merchants (11M+ products). REST API + MCP server for AI agents. | stdio, streamable-http | [Homepage](https://buywhere.ai)<br>[GitHub](https://github.com/BuyWhere/buywhere-mcp)<br>[Package](https://www.npmjs.com/package/@buywhere/mcp-server) |
+| Central Command | 39-endpoint crypto trading intelligence MCP — funding rates, liquidations, counter-trade alpha, backtests, and paper-first agent console. Pay-per-use x402 (Base USDC) or prepaid X-Api-Key. | streamable-http | [Homepage](https://rtcelwjnrbmfmrywacky.supabase.co/functions/v1/x402-docs)<br>[GitHub](https://github.com/tlefko/central-command) |
 | The Stall | 191 pay-per-call data tools via x402 on Base — stocks, crypto/DeFi, macro, SEC filings, compliance, global news, social momentum. No API keys. | streamable-http | [Homepage](https://the-stall.intuitek.ai)<br>[GitHub](https://github.com/thebrierfox/the-stall) |
 | Xquik MCP Server | MCP server for exploring Xquik's X data API and running source-backed X data workflows. | streamable-http | [Homepage](https://docs.xquik.com/mcp/overview)<br>[GitHub](https://github.com/Xquik-dev/x-twitter-scraper) |
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ node scripts/generate-readme.mjs
 | Server | Description | Transport | Links |
 |---|---|---|---|
 | BuyWhere | Real-time product search and price comparison across 15+ Singapore/SEA merchants (11M+ products). REST API + MCP server for AI agents. | stdio, streamable-http | [Homepage](https://buywhere.ai)<br>[GitHub](https://github.com/BuyWhere/buywhere-mcp)<br>[Package](https://www.npmjs.com/package/@buywhere/mcp-server) |
-| Central Command | 39-endpoint crypto trading intelligence MCP — funding rates, liquidations, counter-trade alpha, backtests, and paper-first agent console. Pay-per-use x402 (Base USDC) or prepaid X-Api-Key. | streamable-http | [Homepage](https://rtcelwjnrbmfmrywacky.supabase.co/functions/v1/x402-docs)<br>[GitHub](https://github.com/tlefko/central-command) |
+| Central Command | 39-endpoint crypto trading intelligence MCP — funding rates, liquidations, counter-trade alpha, backtests, and paper-first agent console. Pay-per-use x402 (Base USDC) or prepaid X-Api-Key. | streamable-http | [Homepage](https://rtcelwjnrbmfmrywacky.supabase.co/functions/v1/x402-docs)<br>[GitHub](https://rtcelwjnrbmfmrywacky.supabase.co/functions/v1/x402-docs) |
 | The Stall | 191 pay-per-call data tools via x402 on Base — stocks, crypto/DeFi, macro, SEC filings, compliance, global news, social momentum. No API keys. | streamable-http | [Homepage](https://the-stall.intuitek.ai)<br>[GitHub](https://github.com/thebrierfox/the-stall) |
 | Xquik MCP Server | MCP server for exploring Xquik's X data API and running source-backed X data workflows. | streamable-http | [Homepage](https://docs.xquik.com/mcp/overview)<br>[GitHub](https://github.com/Xquik-dev/x-twitter-scraper) |
 

--- a/servers/data/central-command/server.json
+++ b/servers/data/central-command/server.json
@@ -1,0 +1,23 @@
+{
+  "slug": "central-command",
+  "name": "Central Command",
+  "category": "data",
+  "description": "39-endpoint crypto trading intelligence MCP — funding rates, liquidations, counter-trade alpha, backtests, and paper-first agent console. Pay-per-use x402 (Base USDC) or prepaid X-Api-Key.",
+  "homepage_url": "https://rtcelwjnrbmfmrywacky.supabase.co/functions/v1/x402-docs",
+  "repository_url": "https://github.com/tlefko/central-command",
+  "package_url": "",
+  "transports": ["streamable-http"],
+  "tools": [
+    "list_catalog",
+    "cc_fear_greed",
+    "cc_funding_rates",
+    "agent_strategy",
+    "cc_liquidations"
+  ],
+  "license": "MIT",
+  "provider": {
+    "name": "Central Command",
+    "url": "https://github.com/tlefko/central-command"
+  },
+  "status": "active"
+}


### PR DESCRIPTION
## Summary
Adds `servers/data/central-command/server.json` and regenerates README.

- Transport: streamable-http
- URL: https://rtcelwjnrbmfmrywacky.supabase.co/functions/v1/mcp
- Pricing: x402 pay-per-use (Base USDC) or prepaid X-Api-Key

Validated with `node scripts/validate-catalog.mjs` + `generate-readme.mjs`.