### PR TITLE
Add UIZZE UI reference MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ node scripts/generate-readme.mjs
 
 | Server | Description | Transport | Links |
 |---|---|---|---|
-| UIZZE | UI reference MCP for Codex, Claude Code, Cursor, and Copilot with 800,000+ real web and iOS screens, product-specific design contracts, implementation validation, audits, and screenshot critique. | streamable-http | [Homepage](https://uizze.com)<br>[GitHub](https://github.com/aislon/uizze-mcp)<br>[Package](https://uizze.com/mcp) |
+| UIZZE | UI reference MCP for Codex, Claude Code, Cursor, and Copilot with 800,000+ real web and iOS screens, product-specific design contracts, implementation validation, audits, and screenshot critique. | streamable-http | [Homepage](https://uizze.com)<br>[GitHub](https://github.com/uizze/uizze-mcp)<br>[Package](https://uizze.com/mcp) |
 
 ### Knowledge
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ node scripts/generate-readme.mjs
 | The Stall | 191 pay-per-call data tools via x402 on Base — stocks, crypto/DeFi, macro, SEC filings, compliance, global news, social momentum. No API keys. | streamable-http | [Homepage](https://the-stall.intuitek.ai)<br>[GitHub](https://github.com/thebrierfox/the-stall) |
 | Xquik MCP Server | MCP server for exploring Xquik's X data API and running source-backed X data workflows. | streamable-http | [Homepage](https://docs.xquik.com/mcp/overview)<br>[GitHub](https://github.com/Xquik-dev/x-twitter-scraper) |
 
+### Design
+
+| Server | Description | Transport | Links |
+|---|---|---|---|
+| UIZZE | UI reference MCP for Codex, Claude Code, Cursor, and Copilot with 800,000+ real web and iOS screens, product-specific design contracts, implementation validation, audits, and screenshot critique. | streamable-http | [Homepage](https://uizze.com)<br>[GitHub](https://github.com/aislon/uizze-mcp)<br>[Package](https://uizze.com/mcp) |
+
 ### Knowledge
 
 | Server | Description | Transport | Links |

--- a/servers/design/uizze/server.json
+++ b/servers/design/uizze/server.json
@@ -1,0 +1,28 @@
+{
+  "slug": "uizze",
+  "name": "UIZZE",
+  "category": "design",
+  "description": "UI reference MCP for Codex, Claude Code, Cursor, and Copilot with 800,000+ real web and iOS screens, product-specific design contracts, implementation validation, audits, and screenshot critique.",
+  "homepage_url": "https://uizze.com",
+  "repository_url": "https://github.com/aislon/uizze-mcp",
+  "package_url": "https://uizze.com/mcp",
+  "transports": [
+    "streamable-http"
+  ],
+  "tools": [
+    "create_ui_design_contract",
+    "search_ui_references",
+    "validate_implementation_manifest",
+    "audit_implemented_ui",
+    "critique_implemented_ui",
+    "get_screen_reference",
+    "get_app_reference_pack",
+    "get_flow_reference_pack"
+  ],
+  "license": "MIT",
+  "provider": {
+    "name": "UIZZE",
+    "url": "https://uizze.com"
+  },
+  "status": "active"
+}

--- a/servers/design/uizze/server.json
+++ b/servers/design/uizze/server.json
@@ -4,7 +4,7 @@
   "category": "design",
   "description": "UI reference MCP for Codex, Claude Code, Cursor, and Copilot with 800,000+ real web and iOS screens, product-specific design contracts, implementation validation, audits, and screenshot critique.",
   "homepage_url": "https://uizze.com",
-  "repository_url": "https://github.com/aislon/uizze-mcp",
+  "repository_url": "https://github.com/uizze/uizze-mcp",
   "package_url": "https://uizze.com/mcp",
   "transports": [
     "streamable-http"


### PR DESCRIPTION
## Summary

- add UIZZE as a Design MCP server
- include the direct product URL, canonical repository, transport, and documented tools
- regenerate the catalog README

## Verification

- `node scripts/validate-catalog.mjs`
- `node scripts/generate-readme.mjs`
- `node scripts/validate-catalog.mjs`
- verified the public site and canonical repository
- confirmed there is no existing UIZZE catalog entry, issue, or pull request

Disclosure: I maintain UIZZE and am submitting its official MCP repository.