### PR TITLE
Add Taisly social media posting MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ node scripts/generate-readme.mjs
 
 ## Directory
 
+### Communication
+
+| Server | Description | Transport | Links |
+|---|---|---|---|
+| Taisly Social Media Posting | Publish and schedule short-form videos to TikTok, Instagram Reels, YouTube Shorts, X, and Facebook. | streamable-http, stdio | [Homepage](https://taisly.com/en/ai-agent-kit)<br>[GitHub](https://github.com/taisly/agent)<br>[Package](https://www.npmjs.com/package/@taisly/agent) |
+
 ### Data
 
 | Server | Description | Transport | Links |

--- a/servers/communication/taisly/server.json
+++ b/servers/communication/taisly/server.json
@@ -1,0 +1,34 @@
+{
+  "slug": "taisly",
+  "name": "Taisly Social Media Posting",
+  "category": "communication",
+  "description": "Publish and schedule short-form videos to TikTok, Instagram Reels, YouTube Shorts, X, and Facebook.",
+  "homepage_url": "https://taisly.com/en/ai-agent-kit",
+  "repository_url": "https://github.com/taisly/agent",
+  "package_url": "https://www.npmjs.com/package/@taisly/agent",
+  "transports": [
+    "streamable-http",
+    "stdio"
+  ],
+  "tools": [
+    "taisly_agent_setup_start",
+    "taisly_agent_checkin",
+    "taisly_auth_status",
+    "taisly_platforms_list",
+    "taisly_platform_schema",
+    "taisly_platform_connect_start",
+    "taisly_platform_connect_check",
+    "taisly_posts_validate",
+    "taisly_posts_create",
+    "taisly_posts_status",
+    "taisly_posts_list",
+    "taisly_reposts_list",
+    "taisly_reposts_create"
+  ],
+  "license": "MIT",
+  "provider": {
+    "name": "Taisly",
+    "url": "https://taisly.com/en"
+  },
+  "status": "active"
+}


### PR DESCRIPTION
## Submission checklist

- [x] I added exactly one MCP server entry under `servers/<category>/<slug>/`.
- [x] The entry has a stable public URL.
- [x] The entry category matches its folder.
- [x] I validated the entry structure and JSON.
- [x] I regenerated `README.md` using the catalog's ordering and table format.

## What this adds

Taisly is an official remote and local MCP server for publishing and scheduling short-form videos across TikTok, Instagram Reels, YouTube Shorts, X, and Facebook.

## Notes for maintainers

The hosted endpoint is live, uses Streamable HTTP with OAuth, and the open-source npm package provides the local stdio transport.