### PR TITLE
Add DepthFeed prediction-market data MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ node scripts/generate-readme.mjs
 | Server | Description | Transport | Links |
 |---|---|---|---|
 | BuyWhere | Real-time product search and price comparison across 15+ Singapore/SEA merchants (11M+ products). REST API + MCP server for AI agents. | stdio, streamable-http | [Homepage](https://buywhere.ai)<br>[GitHub](https://github.com/BuyWhere/buywhere-mcp)<br>[Package](https://www.npmjs.com/package/@buywhere/mcp-server) |
+| DepthFeed | Read-only live and historical prediction-market order books from Polymarket, Kalshi, and Limitless, with keyless access to start. | streamable-http | [Homepage](https://depthfeed.com/mcp)<br>[GitHub](https://github.com/vcorp-dev/depthfeed-mcp)<br>[Package](https://registry.modelcontextprotocol.io/v0.1/servers?search=com.depthfeed/depthfeed) |
 | The Stall | 191 pay-per-call data tools via x402 on Base — stocks, crypto/DeFi, macro, SEC filings, compliance, global news, social momentum. No API keys. | streamable-http | [Homepage](https://the-stall.intuitek.ai)<br>[GitHub](https://github.com/thebrierfox/the-stall) |
 | Xquik MCP Server | MCP server for exploring Xquik's X data API and running source-backed X data workflows. | streamable-http | [Homepage](https://docs.xquik.com/mcp/overview)<br>[GitHub](https://github.com/Xquik-dev/x-twitter-scraper) |
 

--- a/servers/data/depthfeed/server.json
+++ b/servers/data/depthfeed/server.json
@@ -1,0 +1,23 @@
+{
+  "slug": "depthfeed",
+  "name": "DepthFeed",
+  "category": "data",
+  "description": "Read-only live and historical prediction-market order books from Polymarket, Kalshi, and Limitless, with keyless access to start.",
+  "homepage_url": "https://depthfeed.com/mcp",
+  "repository_url": "https://github.com/vcorp-dev/depthfeed-mcp",
+  "package_url": "https://registry.modelcontextprotocol.io/v0.1/servers?search=com.depthfeed/depthfeed",
+  "transports": [
+    "streamable-http"
+  ],
+  "tools": [
+    "market search",
+    "order-book snapshots",
+    "cross-venue screener"
+  ],
+  "license": "Proprietary",
+  "provider": {
+    "name": "DepthFeed",
+    "url": "https://depthfeed.com"
+  },
+  "status": "active"
+}


### PR DESCRIPTION
## Summary

Adds one structured catalog entry for DepthFeed under Data and regenerates the README.

DepthFeed is an official remote, read-only Streamable HTTP MCP server for live and historical Polymarket, Kalshi, and Limitless order books, market search, snapshots, and cross-venue screening.

## Validation

- `node scripts/validate-catalog.mjs` → 11 entries validated
- `node scripts/generate-readme.mjs` → README regenerated
- `git diff --check` → passed
- Live `tools/list` request → valid response

Affiliation disclosure: I am affiliated with DepthFeed and am submitting this first-party listing for maintainer review.