### PR TITLE
Add DomScan

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ node scripts/generate-readme.mjs
 |---|---|---|---|
 | ax | Local-first transcript and telemetry graph for AI coding agents, with read-only MCP queries for sessions, tool use, skills, costs, and dispatch/routing analytics. | stdio | [Homepage](https://github.com/Necmttn/ax)<br>[GitHub](https://github.com/Necmttn/ax) |
 
+### Security
+
+| Server | Description | Transport | Links |
+|---|---|---|---|
+| DomScan | Hosted domain intelligence MCP for availability, DNS, WHOIS/RDAP, TLS, subdomains, reputation, email authentication, valuation, and brand monitoring. | streamable-http, stdio | [Homepage](https://domscan.net/mcp-domain-checker)<br>[GitHub](https://github.com/estevecastells/domscan-mcp)<br>[Package](https://domscan.net/mcp) |
+
 ## Repository format
 
 - `CONTRIBUTING.md` explains the review policy.

--- a/servers/security/domscan/server.json
+++ b/servers/security/domscan/server.json
@@ -1,0 +1,19 @@
+{
+  "slug": "domscan",
+  "name": "DomScan",
+  "category": "security",
+  "description": "Hosted domain intelligence MCP for availability, DNS, WHOIS/RDAP, TLS, subdomains, reputation, email authentication, valuation, and brand monitoring.",
+  "homepage_url": "https://domscan.net/mcp-domain-checker",
+  "repository_url": "https://github.com/estevecastells/domscan-mcp",
+  "package_url": "https://domscan.net/mcp",
+  "transports": [
+    "streamable-http",
+    "stdio"
+  ],
+  "license": "MIT (public wrapper; hosted service)",
+  "provider": {
+    "name": "DomScan",
+    "url": "https://domscan.net"
+  },
+  "status": "active"
+}


### PR DESCRIPTION
Adds one catalog entry for DomScan in the `security` category.

DomScan is a hosted domain-intelligence MCP server covering availability, DNS, WHOIS/RDAP, TLS, public subdomains, reputation, email authentication, valuation, and brand monitoring. The public repository documents both Streamable HTTP and stdio setup.

Validation:

- `node scripts/validate-catalog.mjs` — passed
- `node scripts/generate-readme.mjs` — regenerated README
- `git diff --check` — passed
- Homepage, repository, and endpoint URLs are reachable