### PR TITLE
Add Talivia MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ node scripts/generate-readme.mjs
 | Server | Description | Transport | Links |
 |---|---|---|---|
 | BuyWhere | Real-time product search and price comparison across 15+ Singapore/SEA merchants (11M+ products). REST API + MCP server for AI agents. | stdio, streamable-http | [Homepage](https://buywhere.ai)<br>[GitHub](https://github.com/BuyWhere/buywhere-mcp)<br>[Package](https://www.npmjs.com/package/@buywhere/mcp-server) |
+| Talivia Revenue Analytics | Install and verify revenue-first website analytics, then connect traffic and customer journeys to payment attribution. | streamable-http, stdio | [Homepage](https://talivia.com/ai-agent-kit)<br>[GitHub](https://github.com/talivia-group/agent)<br>[Package](https://www.npmjs.com/package/@talivia/agent) |
 | The Stall | 191 pay-per-call data tools via x402 on Base — stocks, crypto/DeFi, macro, SEC filings, compliance, global news, social momentum. No API keys. | streamable-http | [Homepage](https://the-stall.intuitek.ai)<br>[GitHub](https://github.com/thebrierfox/the-stall) |
 | Xquik MCP Server | MCP server for exploring Xquik's X data API and running source-backed X data workflows. | streamable-http | [Homepage](https://docs.xquik.com/mcp/overview)<br>[GitHub](https://github.com/Xquik-dev/x-twitter-scraper) |
 

--- a/servers/data/talivia/server.json
+++ b/servers/data/talivia/server.json
@@ -1,0 +1,31 @@
+{
+  "slug": "talivia",
+  "name": "Talivia Revenue Analytics",
+  "category": "data",
+  "description": "Install and verify revenue-first website analytics, then connect traffic and customer journeys to payment attribution.",
+  "homepage_url": "https://talivia.com/ai-agent-kit",
+  "repository_url": "https://github.com/talivia-group/agent",
+  "package_url": "https://www.npmjs.com/package/@talivia/agent",
+  "transports": [
+    "streamable-http",
+    "stdio"
+  ],
+  "tools": [
+    "talivia_account_status",
+    "talivia_websites_list",
+    "talivia_websites_create",
+    "talivia_tracking_snippet_get",
+    "talivia_framework_install_plan_get",
+    "talivia_setup_status_get",
+    "talivia_tracker_verify",
+    "talivia_payment_connect_start",
+    "talivia_payment_status_get",
+    "talivia_checkout_attribution_guide_get"
+  ],
+  "license": "MIT",
+  "provider": {
+    "name": "Talivia",
+    "url": "https://talivia.com"
+  },
+  "status": "active"
+}


### PR DESCRIPTION
Talivia is revenue-first website analytics installed and verified by AI agents through MCP.

Official resources:
- Source: https://github.com/talivia-group/agent
- Hosted OAuth MCP: `https://talivia.com/mcp`
- npm: `@talivia/agent` version `0.1.0`
- Official MCP Registry: `io.github.talivia-group/agent`
- Integration guide: https://talivia.com/ai-agent-kit

The server helps agents install tracking, verify live events, connect payment attribution through a secure browser flow, and identify which referrers, campaigns, pages, and customer journeys become revenue.

Validation performed:
- `node scripts/validate-catalog.mjs`
- `node scripts/generate-readme.mjs`
- `node scripts/validate-catalog.mjs`

All commands pass.