### PR TITLE
Add AgentServices — x402-paid crypto/market data APIs with 37 MCP tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ node scripts/generate-readme.mjs
 |---|---|---|---|
 | AgentServices | 37 MCP tools serving 54 x402-paid crypto/financial market data endpoints on Base — spot prices, OHLCV, on-chain metrics, FX, and bundled research synthesis for AI agents. | streamable-http | [Homepage](https://agentservices.to)<br>[GitHub](https://github.com/vbkotecha/aiservices-api) |
 | BuyWhere | Real-time product search and price comparison across 15+ Singapore/SEA merchants (11M+ products). REST API + MCP server for AI agents. | stdio, streamable-http | [Homepage](https://buywhere.ai)<br>[GitHub](https://github.com/BuyWhere/buywhere-mcp)<br>[Package](https://www.npmjs.com/package/@buywhere/mcp-server) |
+| AgentServices | x402-paid crypto/market data APIs with 37 MCP tools — BTC indicators, DeFi stats, macro data, exchange analytics | streamable-http | [Repo](https://github.com/vbkotecha/agentservices-api) · [Site](https://agentservices.to) · [MCP](https://api.agentservices.to/mcp) |
 | The Stall | 191 pay-per-call data tools via x402 on Base — stocks, crypto/DeFi, macro, SEC filings, compliance, global news, social momentum. No API keys. | streamable-http | [Homepage](https://the-stall.intuitek.ai)<br>[GitHub](https://github.com/thebrierfox/the-stall) |
 | Xquik MCP Server | MCP server for exploring Xquik's X data API and running source-backed X data workflows. | streamable-http | [Homepage](https://docs.xquik.com/mcp/overview)<br>[GitHub](https://github.com/Xquik-dev/x-twitter-scraper) |
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ node scripts/generate-readme.mjs
 
 | Server | Description | Transport | Links |
 |---|---|---|---|
+| AgentServices | 37 MCP tools serving 54 x402-paid crypto/financial market data endpoints on Base — spot prices, OHLCV, on-chain metrics, FX, and bundled research synthesis for AI agents. | streamable-http | [Homepage](https://agentservices.to)<br>[GitHub](https://github.com/vbkotecha/aiservices-api) |
 | BuyWhere | Real-time product search and price comparison across 15+ Singapore/SEA merchants (11M+ products). REST API + MCP server for AI agents. | stdio, streamable-http | [Homepage](https://buywhere.ai)<br>[GitHub](https://github.com/BuyWhere/buywhere-mcp)<br>[Package](https://www.npmjs.com/package/@buywhere/mcp-server) |
 | The Stall | 191 pay-per-call data tools via x402 on Base — stocks, crypto/DeFi, macro, SEC filings, compliance, global news, social momentum. No API keys. | streamable-http | [Homepage](https://the-stall.intuitek.ai)<br>[GitHub](https://github.com/thebrierfox/the-stall) |
 | Xquik MCP Server | MCP server for exploring Xquik's X data API and running source-backed X data workflows. | streamable-http | [Homepage](https://docs.xquik.com/mcp/overview)<br>[GitHub](https://github.com/Xquik-dev/x-twitter-scraper) |

--- a/repositories.yaml
+++ b/repositories.yaml
@@ -1,0 +1,5 @@
+{
+  "message": "Not Found",
+  "documentation_url": "https://docs.github.com/rest/repos/contents#get-repository-content",
+  "status": "404"
+}

--- a/servers/data/agentservices/server.json
+++ b/servers/data/agentservices/server.json
@@ -1,0 +1,16 @@
+{
+  "slug": "agentservices",
+  "name": "AgentServices",
+  "category": "data",
+  "description": "37 MCP tools serving 54 x402-paid crypto/financial market data endpoints on Base — spot prices, OHLCV, on-chain metrics, FX, and bundled research synthesis for AI agents.",
+  "homepage_url": "https://agentservices.to",
+  "repository_url": "https://github.com/vbkotecha/aiservices-api",
+  "transports": ["streamable-http"],
+  "tools": [
+    "crypto-spot-prices", "ohlcv-candles", "onchain-metrics", "fx-rates",
+    "market-depth", "token-info", "defi-pool-data", "gas-tracker",
+    "exchange-rates", "historical-prices", "market-cap", "trading-volume"
+  ],
+  "license": "MIT",
+  "status": "active"
+}


### PR DESCRIPTION
## AgentServices — x402-Paid Crypto/Market Data APIs

- **54 API services** across crypto, DeFi, macro, and exchange data
- **37 MCP tools** via streamable-http transport
- **41 x402-paid endpoints** (pay-per-call with USDC on Base)
- **Live**: https://agentservices.to
- **MCP endpoint**: https://api.agentservices.to/mcp
- **npm**: @agentservices/client

Production-deployed on Railway. Listed in MCP Registry as `to.agentservices/agentservices`.