### PR TITLE
Add NotFair marketing MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ node scripts/generate-readme.mjs
 | Server | Description | Transport | Links |
 |---|---|---|---|
 | BuyWhere | Real-time product search and price comparison across 15+ Singapore/SEA merchants (11M+ products). REST API + MCP server for AI agents. | stdio, streamable-http | [Homepage](https://buywhere.ai)<br>[GitHub](https://github.com/BuyWhere/buywhere-mcp)<br>[Package](https://www.npmjs.com/package/@buywhere/mcp-server) |
+| NotFair | Connect AI clients to Google Ads, Meta Ads, X Ads, Google Search Console, and Google Analytics with OAuth, approval-gated writes, and change history. | streamable-http | [Homepage](https://notfair.co) |
 | Talivia Revenue Analytics | Install and verify revenue-first website analytics, then connect traffic and customer journeys to payment attribution. | streamable-http, stdio | [Homepage](https://talivia.com/ai-agent-kit)<br>[GitHub](https://github.com/talivia-group/agent)<br>[Package](https://www.npmjs.com/package/@talivia/agent) |
 | The Stall | 191 pay-per-call data tools via x402 on Base — stocks, crypto/DeFi, macro, SEC filings, compliance, global news, social momentum. No API keys. | streamable-http | [Homepage](https://the-stall.intuitek.ai)<br>[GitHub](https://github.com/thebrierfox/the-stall) |
 | Xquik MCP Server | MCP server for exploring Xquik's X data API and running source-backed X data workflows. | streamable-http | [Homepage](https://docs.xquik.com/mcp/overview)<br>[GitHub](https://github.com/Xquik-dev/x-twitter-scraper) |

--- a/servers/data/notfair/server.json
+++ b/servers/data/notfair/server.json
@@ -1,0 +1,16 @@
+{
+  "slug": "notfair",
+  "name": "NotFair",
+  "category": "data",
+  "description": "Connect AI clients to Google Ads, Meta Ads, X Ads, Google Search Console, and Google Analytics with OAuth, approval-gated writes, and change history.",
+  "homepage_url": "https://notfair.co",
+  "transports": [
+    "streamable-http"
+  ],
+  "license": "Proprietary",
+  "provider": {
+    "name": "NotFair",
+    "url": "https://notfair.co"
+  },
+  "status": "active"
+}


### PR DESCRIPTION
## Submission checklist

- [x] I added or updated exactly one MCP server entry under `servers/<category>/<slug>/`.
- [x] The entry has a stable public URL.
- [x] The entry category matches its folder.
- [x] I ran `node scripts/validate-catalog.mjs`.
- [x] I ran `node scripts/generate-readme.mjs`.
- [x] I confirmed `README.md` is generated and committed if it changed.

## What this adds

Adds NotFair, a hosted Streamable HTTP MCP service for Google Ads, Meta Ads, X Ads, Google Search Console, and Google Analytics. The entry notes OAuth account connections, approval-gated writes, and change history.

## Notes for maintainers

The hosted service is listed as proprietary; the separate public NotFair skills repository is not presented as the server source. `node scripts/validate-catalog.mjs` passes with 13 entries, and the README was regenerated.