### PR TITLE
Add Autoposting to Communication

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ node scripts/generate-readme.mjs
 
 | Server | Description | Transport | Links |
 |---|---|---|---|
+| Autoposting | Generate, schedule and publish social posts to X, LinkedIn, Instagram, Threads and YouTube, plus video clipping and carousel building. | streamable-http | [Homepage](https://autoposting.ai)<br>[GitHub](https://github.com/Autoposting-ai/autoposting-mcp) |
 | Taisly Social Media Posting | Publish and schedule short-form videos to TikTok, Instagram Reels, YouTube Shorts, X, and Facebook. | streamable-http, stdio | [Homepage](https://taisly.com/en/ai-agent-kit)<br>[GitHub](https://github.com/taisly/agent)<br>[Package](https://www.npmjs.com/package/@taisly/agent) |
 
 ### Data


### PR DESCRIPTION
Adds Autoposting to the Communication directory.

Remote MCP server over Streamable HTTP with OAuth 2.1 dynamic client registration at `https://app.autoposting.ai/mcp`. Tools cover post generation, scheduling, publishing, carousels, video clipping and knowledge bases across X, LinkedIn, Instagram, Threads and YouTube.

One table row added, columns match the existing Server / Description / Transport / Links format.