### PR TITLE
Add OrkasVideoStudio MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ node scripts/generate-readme.mjs
 
 | Server | Description | Transport | Links |
 |---|---|---|---|
+| OrkasVideoStudio | Local TypeScript MCP server and CLI for coding-agent-driven video composition, editing, analysis, captions, transcription, and rendering with editable plan.json timelines. | stdio | [Homepage](https://github.com/Orkas-AI/Orkas-VideoStudio)<br>[GitHub](https://github.com/Orkas-AI/Orkas-VideoStudio) |
 | UIZZE | UI reference MCP for Codex, Claude Code, Cursor, and Copilot with 800,000+ real web and iOS screens, product-specific design contracts, implementation validation, audits, and screenshot critique. | streamable-http | [Homepage](https://uizze.com)<br>[GitHub](https://github.com/uizze/uizze-mcp)<br>[Package](https://uizze.com/mcp) |
 
 ### Knowledge

--- a/servers/design/orkas-videostudio/server.json
+++ b/servers/design/orkas-videostudio/server.json
@@ -1,0 +1,29 @@
+{
+  "slug": "orkas-videostudio",
+  "name": "OrkasVideoStudio",
+  "category": "design",
+  "description": "Local TypeScript MCP server and CLI for coding-agent-driven video composition, editing, analysis, captions, transcription, and rendering with editable plan.json timelines.",
+  "homepage_url": "https://github.com/Orkas-AI/Orkas-VideoStudio",
+  "repository_url": "https://github.com/Orkas-AI/Orkas-VideoStudio",
+  "transports": [
+    "stdio"
+  ],
+  "tools": [
+    "draft",
+    "render",
+    "edit_trim",
+    "edit_concat",
+    "edit_burnsubs",
+    "edit_mix",
+    "transcribe",
+    "scenes",
+    "quality",
+    "plan_promise_check"
+  ],
+  "license": "MIT",
+  "provider": {
+    "name": "Orkas-AI",
+    "url": "https://github.com/Orkas-AI"
+  },
+  "status": "active"
+}


### PR DESCRIPTION
## Submission checklist

- [x] I added or updated exactly one MCP server entry under `servers/<category>/<slug>/`.
- [x] The entry has a stable public URL.
- [x] The entry category matches its folder.
- [x] I ran `node scripts/validate-catalog.mjs`.
- [x] I ran `node scripts/generate-readme.mjs`.
- [x] I confirmed `README.md` is generated and committed if it changed.

## What this adds

OrkasVideoStudio, a local TypeScript stdio MCP server and CLI for coding-agent-driven video composition, editing, analysis, captions, transcription, and rendering with editable timelines.

## Notes for maintainers

The entry links to the canonical MIT repository and lists representative tool names verified from the MCP source. npm publication is still pending, so no package URL is claimed.