### PR TITLE
Add SandBase Harness MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ node scripts/generate-readme.mjs
 |---|---|---|---|
 | UIZZE | UI reference MCP for Codex, Claude Code, Cursor, and Copilot with 800,000+ real web and iOS screens, product-specific design contracts, implementation validation, audits, and screenshot critique. | streamable-http | [Homepage](https://uizze.com)<br>[GitHub](https://github.com/uizze/uizze-mcp)<br>[Package](https://uizze.com/mcp) |
 
+### Developer Tools
+
+| Server | Description | Transport | Links |
+|---|---|---|---|
+| SandBase Harness | Model-agnostic managed-agent runtime with a stdio MCP bridge for persistent sandboxed sessions, streamed runs, artifacts, cancellation, audit, and replay. | stdio | [Homepage](https://github.com/sandbaseai/sandbase-harness)<br>[GitHub](https://github.com/sandbaseai/sandbase-harness) |
+
 ### Knowledge
 
 | Server | Description | Transport | Links |

--- a/servers/developer-tools/sandbase-harness/server.json
+++ b/servers/developer-tools/sandbase-harness/server.json
@@ -1,0 +1,25 @@
+{
+  "slug": "sandbase-harness",
+  "name": "SandBase Harness",
+  "category": "developer-tools",
+  "description": "Model-agnostic managed-agent runtime with a stdio MCP bridge for persistent sandboxed sessions, streamed runs, artifacts, cancellation, audit, and replay.",
+  "homepage_url": "https://github.com/sandbaseai/sandbase-harness",
+  "repository_url": "https://github.com/sandbaseai/sandbase-harness",
+  "transports": [
+    "stdio"
+  ],
+  "tools": [
+    "list_agents",
+    "create_session",
+    "run_session",
+    "get_session",
+    "list_artifacts",
+    "stop_session"
+  ],
+  "license": "Apache-2.0",
+  "provider": {
+    "name": "SandBase AI",
+    "url": "https://github.com/sandbaseai"
+  },
+  "status": "active"
+}


### PR DESCRIPTION
## Submission checklist

- [x] I added or updated exactly one MCP server entry under `servers/<category>/<slug>/`.
- [x] The entry has a stable public URL.
- [x] The entry category matches its folder.
- [x] I ran `node scripts/validate-catalog.mjs`.
- [x] I ran `node scripts/generate-readme.mjs`.
- [x] I confirmed `README.md` is generated and committed if it changed.

## What this adds

Adds SandBase Harness to Developer Tools. Its stdio MCP bridge exposes six tools for persistent sandboxed agent sessions, streamed execution, artifacts, cancellation, audit, and replay. The entry points to the public Apache-2.0 repository and records the exact exposed tool names.

## Notes for maintainers

Validated 14 catalog entries and regenerated the README locally. The upstream project publishes immutable releases; v0.3.1 is the current tested release.

Disclosure: this submission was prepared with AI assistance for the SandBase project.
