### PR TITLE
Add Palisade DMARC Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ node scripts/generate-readme.mjs
 | Server | Description | Transport | Links |
 |---|---|---|---|
 | DomScan | Hosted domain intelligence MCP for availability, DNS, WHOIS/RDAP, TLS, subdomains, reputation, email authentication, valuation, and brand monitoring. | streamable-http, stdio | [Homepage](https://domscan.net/mcp-domain-checker)<br>[GitHub](https://github.com/estevecastells/domscan-mcp)<br>[Package](https://domscan.net/mcp) |
-| Palisade DMARC Agent | AI-powered email-authentication management for DMARC, SPF, DKIM, BIMI, MTA-STS, DNS, and remediation tasks. | streamable-http, stdio | [Homepage](https://palisade.email)<br>[GitHub](https://github.com/palisadeemail/palisade-mcp)<br>[Package](https://www.npmjs.com/package/@palisadeemail/mcp) |
+| Palisade DMARC Agent | AI-powered email-authentication management for DMARC, SPF, DKIM, BIMI, MTA-STS, DNS, and remediation tasks. | streamable-http, stdio | [Homepage](https://www.palisade.email/mcp)<br>[GitHub](https://github.com/palisadeemail/palisade-mcp)<br>[Package](https://www.npmjs.com/package/@palisadeemail/mcp) |
 
 ## Repository format
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ node scripts/generate-readme.mjs
 | Server | Description | Transport | Links |
 |---|---|---|---|
 | DomScan | Hosted domain intelligence MCP for availability, DNS, WHOIS/RDAP, TLS, subdomains, reputation, email authentication, valuation, and brand monitoring. | streamable-http, stdio | [Homepage](https://domscan.net/mcp-domain-checker)<br>[GitHub](https://github.com/estevecastells/domscan-mcp)<br>[Package](https://domscan.net/mcp) |
+| Palisade DMARC Agent | AI-powered email-authentication management for DMARC, SPF, DKIM, BIMI, MTA-STS, DNS, and remediation tasks. | streamable-http, stdio | [Homepage](https://palisade.email)<br>[GitHub](https://github.com/palisadeemail/palisade-mcp)<br>[Package](https://www.npmjs.com/package/@palisadeemail/mcp) |
 
 ## Repository format
 

--- a/servers/security/palisade-dmarc-agent/server.json
+++ b/servers/security/palisade-dmarc-agent/server.json
@@ -3,7 +3,7 @@
   "name": "Palisade DMARC Agent",
   "category": "security",
   "description": "AI-powered email-authentication management for DMARC, SPF, DKIM, BIMI, MTA-STS, DNS, and remediation tasks.",
-  "homepage_url": "https://palisade.email",
+  "homepage_url": "https://www.palisade.email/mcp",
   "repository_url": "https://github.com/palisadeemail/palisade-mcp",
   "package_url": "https://www.npmjs.com/package/@palisadeemail/mcp",
   "documentation_url": "https://developer.palisade.email/docs/guide",
@@ -42,7 +42,7 @@
   },
   "provider": {
     "name": "Palisade",
-    "url": "https://palisade.email"
+    "url": "https://www.palisade.email/mcp"
   },
   "license": "MIT",
   "status": "active"

--- a/servers/security/palisade-dmarc-agent/server.json
+++ b/servers/security/palisade-dmarc-agent/server.json
@@ -1,0 +1,49 @@
+{
+  "slug": "palisade-dmarc-agent",
+  "name": "Palisade DMARC Agent",
+  "category": "security",
+  "description": "AI-powered email-authentication management for DMARC, SPF, DKIM, BIMI, MTA-STS, DNS, and remediation tasks.",
+  "homepage_url": "https://palisade.email",
+  "repository_url": "https://github.com/palisadeemail/palisade-mcp",
+  "package_url": "https://www.npmjs.com/package/@palisadeemail/mcp",
+  "documentation_url": "https://developer.palisade.email/docs/guide",
+  "remote_endpoint_url": "https://api.palisade.email/mcp",
+  "transports": [
+    "streamable-http",
+    "stdio"
+  ],
+  "tools": [
+    "get_account",
+    "list_domains",
+    "get_domain",
+    "add_domain",
+    "remove_domain",
+    "get_dns_records",
+    "enable_hosted_dmarc",
+    "verify_domain",
+    "get_mta_sts",
+    "enable_mta_sts",
+    "list_tasks",
+    "get_task",
+    "list_groups",
+    "create_group",
+    "get_subscription",
+    "start_checkout",
+    "get_billing_portal_url",
+    "list_webhook_events",
+    "list_webhook_endpoints",
+    "create_webhook_endpoint",
+    "delete_webhook_endpoint"
+  ],
+  "authentication": {
+    "type": "oauth2-or-api-key",
+    "authorization": "Bearer token",
+    "oauth_metadata_url": "https://api.palisade.email/.well-known/oauth-protected-resource"
+  },
+  "provider": {
+    "name": "Palisade",
+    "url": "https://palisade.email"
+  },
+  "license": "MIT",
+  "status": "active"
+}


### PR DESCRIPTION
## What this adds
- A Security directory entry for Palisade DMARC Agent.
- Its public Streamable HTTP endpoint, local package, documentation, actual MCP tool names, and OAuth/API-key authentication metadata.

## Validation
- `node scripts/validate-catalog.mjs`
- `node scripts/generate-readme.mjs`
- `node scripts/validate-catalog.mjs`

No credentials are included.