### PR TITLE
fix: refresh UIZZE catalog source

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ node scripts/generate-readme.mjs
 
 | Server | Description | Transport | Links |
 |---|---|---|---|
-| UIZZE | UI reference MCP for Codex, Claude Code, Cursor, and Copilot with 800,000+ real web and iOS screens, product-specific design contracts, implementation validation, audits, and screenshot critique. | streamable-http | [Homepage](https://uizze.com)<br>[GitHub](https://github.com/uizze/uizze-mcp)<br>[Package](https://uizze.com/mcp) |
+| UIZZE | Free anti-UI-slop Skill and deterministic no-account preview MCP for coding agents. Full UIZZE adds live research across 800,000+ real web and iOS screens, design contracts, validation, audits, and rendered critique. | streamable-http | [Homepage](https://uizze.com)<br>[GitHub](https://github.com/uizze/uizze)<br>[Package](https://uizze.com/mcp/preview) |
 
 ### Knowledge
 

--- a/servers/design/uizze/server.json
+++ b/servers/design/uizze/server.json
@@ -2,22 +2,15 @@
   "slug": "uizze",
   "name": "UIZZE",
   "category": "design",
-  "description": "UI reference MCP for Codex, Claude Code, Cursor, and Copilot with 800,000+ real web and iOS screens, product-specific design contracts, implementation validation, audits, and screenshot critique.",
+  "description": "Free anti-UI-slop Skill and deterministic no-account preview MCP for coding agents. Full UIZZE adds live research across 800,000+ real web and iOS screens, design contracts, validation, audits, and rendered critique.",
   "homepage_url": "https://uizze.com",
-  "repository_url": "https://github.com/uizze/uizze-mcp",
-  "package_url": "https://uizze.com/mcp",
+  "repository_url": "https://github.com/uizze/uizze",
+  "package_url": "https://uizze.com/mcp/preview",
   "transports": [
     "streamable-http"
   ],
   "tools": [
-    "create_ui_design_contract",
-    "search_ui_references",
-    "validate_implementation_manifest",
-    "audit_implemented_ui",
-    "critique_implemented_ui",
-    "get_screen_reference",
-    "get_app_reference_pack",
-    "get_flow_reference_pack"
+    "check_ui_slop"
   ],
   "license": "MIT",
   "provider": {


### PR DESCRIPTION
## Summary
- replace the retired uizze/uizze-mcp repository link with the canonical uizze/uizze source
- point the listing at the free no-account preview MCP
- describe the free Skill and preview first, with the optional 800,000+ workflow clearly separated
- regenerate the README entry

## Verification
- npm run check
- git diff --check

Canonical source: https://github.com/uizze/uizze/blob/main/integrations/mcp/server.json
Preview: https://uizze.com/mcp/preview