### PR TITLE
docs: add SandBase CLI MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ node scripts/generate-readme.mjs
 | OrkasVideoStudio | Local TypeScript MCP server and CLI for coding-agent-driven video composition, editing, analysis, captions, transcription, and rendering with editable plan.json timelines. | stdio | [Homepage](https://github.com/Orkas-AI/Orkas-VideoStudio)<br>[GitHub](https://github.com/Orkas-AI/Orkas-VideoStudio) |
 | UIZZE | Authenticated UI reference MCP for Codex, Claude Code, Cursor, and Copilot. It provides focused UI reference and hosted design-material search grounded in 800,000+ real web and iOS screens; the free anti-ui-slop Skill and GitHub Action are separate. | streamable-http | [Homepage](https://uizze.com)<br>[GitHub](https://github.com/uizze/uizze)<br>[Package](https://uizze.com/mcp) |
 
+### Developer Tools
+
+| Server | Description | Transport | Links |
+|---|---|---|---|
+| SandBase CLI | Secure local MCP bridge for AI clients to discover, inspect, and run models and APIs from a catalog of 2,000+ models. | stdio | [Homepage](https://github.com/sandbaseai/cli)<br>[GitHub](https://github.com/sandbaseai/cli) |
+
 ### Knowledge
 
 | Server | Description | Transport | Links |

--- a/servers/developer-tools/sandbase-cli/server.json
+++ b/servers/developer-tools/sandbase-cli/server.json
@@ -1,0 +1,25 @@
+{
+  "slug": "sandbase-cli",
+  "name": "SandBase CLI",
+  "category": "developer-tools",
+  "description": "Secure local MCP bridge for AI clients to discover, inspect, and run models and APIs from a catalog of 2,000+ models.",
+  "homepage_url": "https://github.com/sandbaseai/cli",
+  "repository_url": "https://github.com/sandbaseai/cli",
+  "transports": [
+    "stdio"
+  ],
+  "tools": [
+    "sandbase_discover",
+    "sandbase_inspect",
+    "sandbase_run",
+    "sandbase_status",
+    "sandbase_config",
+    "sandbase_help"
+  ],
+  "license": "Apache-2.0",
+  "provider": {
+    "name": "SandBase",
+    "url": "https://sandbase.ai"
+  },
+  "status": "active"
+}


### PR DESCRIPTION
## Summary
- add SandBase CLI to the developer-tools catalog
- document its stdio transport, six MCP tools, Apache-2.0 license, and official repository
- regenerate README as required by the contribution guide

SandBase CLI is an open-source local MCP bridge for AI clients to discover, inspect, and run models and APIs from a catalog of 2,000+ models.

- Official repository: https://github.com/sandbaseai/cli
- MCP Registry: https://registry.modelcontextprotocol.io/?q=io.github.sandbaseai%2Fcli
- npm package: https://www.npmjs.com/package/@sandbaseai/cli
