### PR TITLE
fix: update UIZZE tool inventory

### DIFF
--- a/servers/design/uizze/server.json
+++ b/servers/design/uizze/server.json
@@ -10,14 +10,8 @@
     "streamable-http"
   ],
   "tools": [
-    "create_ui_design_contract",
-    "search_ui_references",
-    "validate_implementation_manifest",
-    "audit_implemented_ui",
-    "critique_implemented_ui",
-    "get_screen_reference",
-    "get_app_reference_pack",
-    "get_flow_reference_pack"
+    "find_ui_references",
+    "find_ui_materials"
   ],
   "license": "MIT",
   "provider": {


### PR DESCRIPTION
The hosted UIZZE MCP now exposes exactly two tools: `find_ui_references` and `find_ui_materials`. This replaces the eight retired tool names in the directory record.

Verified against the live server card: https://uizze.com/.well-known/mcp/server-card.json

Validation: `node scripts/validate-catalog.mjs` and `node scripts/generate-readme.mjs`.