### PR TITLE
feat: add sandbase-harness MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ node scripts/generate-readme.mjs
 | OrkasVideoStudio | Local TypeScript MCP server and CLI for coding-agent-driven video composition, editing, analysis, captions, transcription, and rendering with editable plan.json timelines. | stdio | [Homepage](https://github.com/Orkas-AI/Orkas-VideoStudio)<br>[GitHub](https://github.com/Orkas-AI/Orkas-VideoStudio) |
 | UIZZE | Authenticated UI reference MCP for Codex, Claude Code, Cursor, and Copilot. It provides focused UI reference and hosted design-material search grounded in 800,000+ real web and iOS screens; the free anti-ui-slop Skill and GitHub Action are separate. | streamable-http | [Homepage](https://uizze.com)<br>[GitHub](https://github.com/uizze/uizze)<br>[Package](https://uizze.com/mcp) |
 
+### Developer Tools
+
+| Server | Description | Transport | Links |
+|---|---|---|---|
+| SandBase Harness | Local-first, self-hosted agent runtime with persistent sessions, sandboxed tools, memory, credentials, approvals, audit/replay, and a six-tool MCP bridge. | stdio | [Homepage](https://github.com/sandbaseai/sandbase-harness)<br>[GitHub](https://github.com/sandbaseai/sandbase-harness) |
+
 ### Knowledge
 
 | Server | Description | Transport | Links |

--- a/servers/developer-tools/sandbase-harness/server.json
+++ b/servers/developer-tools/sandbase-harness/server.json
@@ -1,0 +1,21 @@
+{
+  "slug": "sandbase-harness",
+  "name": "SandBase Harness",
+  "category": "developer-tools",
+  "description": "Local-first, self-hosted agent runtime with persistent sessions, sandboxed tools, memory, credentials, approvals, audit/replay, and a six-tool MCP bridge.",
+  "homepage_url": "https://github.com/sandbaseai/sandbase-harness",
+  "repository_url": "https://github.com/sandbaseai/sandbase-harness",
+  "transports": [
+    "stdio"
+  ],
+  "tools": [
+    "list_agents",
+    "create_session",
+    "run_session",
+    "get_session",
+    "list_artifacts",
+    "stop_session"
+  ],
+  "license": "Apache-2.0",
+  "status": "active"
+}


### PR DESCRIPTION
Adds SandBase Harness as a Developer Tools MCP server.

- Current repository source and Apache-2.0 license
- stdio transport
- Six documented tools: list_agents, create_session, run_session, get_session, list_artifacts, stop_session
- Local/Docker/Kubernetes/self-hosted sandbox support is described in the source repository

Validation performed:
- node scripts/validate-catalog.mjs
- node scripts/generate-readme.mjs
- git diff --check

This is a refreshed submission after the earlier closed PR; the entry uses the current v0.3.8 project metadata.