### PR TITLE
Add Process Street MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ node scripts/generate-readme.mjs
 |---|---|---|---|
 | ax | Local-first transcript and telemetry graph for AI coding agents, with read-only MCP queries for sessions, tool use, skills, costs, and dispatch/routing analytics. | stdio | [Homepage](https://github.com/Necmttn/ax)<br>[GitHub](https://github.com/Necmttn/ax) |
 
+### Orchestration
+
+| Server | Description | Transport | Links |
+|---|---|---|---|
+| Process Street | Connect AI agents to Process Street workflows, tasks, runs, data sets, and operational records. | streamable-http | [Homepage](https://www.process.st/help/docs/mcp-server/)<br>[GitHub](https://github.com/process-street/process-street-mcp) |
+
 ### Security
 
 | Server | Description | Transport | Links |

--- a/servers/orchestration/process-street/server.json
+++ b/servers/orchestration/process-street/server.json
@@ -1,0 +1,17 @@
+{
+  "slug": "process-street",
+  "name": "Process Street",
+  "category": "orchestration",
+  "description": "Connect AI agents to Process Street workflows, tasks, runs, data sets, and operational records.",
+  "homepage_url": "https://www.process.st/help/docs/mcp-server/",
+  "repository_url": "https://github.com/process-street/process-street-mcp",
+  "transports": [
+    "streamable-http"
+  ],
+  "license": "Proprietary",
+  "provider": {
+    "name": "Process Street",
+    "url": "https://www.process.st/"
+  },
+  "status": "active"
+}


### PR DESCRIPTION
## Submission checklist

- [x] I added or updated exactly one MCP server entry under `servers/<category>/<slug>/`.
- [x] The entry has a stable public URL.
- [x] The entry category matches its folder.
- [x] I ran `node scripts/validate-catalog.mjs`.
- [x] I ran `node scripts/generate-readme.mjs`.
- [x] I confirmed `README.md` is generated and committed if it changed.

## What this adds

Adds Process Street's official hosted MCP server for workflows, tasks, runs, data sets, and operational records.

## Notes for maintainers

The linked repository contains public discovery metadata for the hosted server. The implementation is private, so the entry is labeled `Proprietary`. The server is published as `io.github.process-street/process-street-mcp` in the Official MCP Registry.