### PR TITLE
Add Zovo Spreadsheet to files

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ node scripts/generate-readme.mjs
 | OrkasVideoStudio | Local TypeScript MCP server and CLI for coding-agent-driven video composition, editing, analysis, captions, transcription, and rendering with editable plan.json timelines. | stdio | [Homepage](https://github.com/Orkas-AI/Orkas-VideoStudio)<br>[GitHub](https://github.com/Orkas-AI/Orkas-VideoStudio) |
 | UIZZE | Authenticated UI reference MCP for Codex, Claude Code, Cursor, and Copilot. It provides focused UI reference and hosted design-material search grounded in 800,000+ real web and iOS screens; the free anti-ui-slop Skill and GitHub Action are separate. | streamable-http | [Homepage](https://uizze.com)<br>[GitHub](https://github.com/uizze/uizze)<br>[Package](https://uizze.com/mcp) |
 
+### Files
+
+| Server | Description | Transport | Links |
+|---|---|---|---|
+| Zovo Spreadsheet | Open, inspect, filter, edit and convert xlsx and csv files. Runs locally over stdio from an mcpb bundle, and is also reachable as a hosted Streamable HTTP endpoint with a free anonymous token. | stdio, streamable-http | [Homepage](https://mcp.zovo.one/s/spreadsheet)<br>[GitHub](https://github.com/theluckystrike/mcp-spreadsheet)<br>[Package](https://mcp.zovo.one/mcp/spreadsheet) |
+
 ### Knowledge
 
 | Server | Description | Transport | Links |

--- a/servers/files/zovo-spreadsheet/server.json
+++ b/servers/files/zovo-spreadsheet/server.json
@@ -1,0 +1,28 @@
+{
+  "slug": "zovo-spreadsheet",
+  "name": "Zovo Spreadsheet",
+  "category": "files",
+  "description": "Open, inspect, filter, edit and convert xlsx and csv files. Runs locally over stdio from an mcpb bundle, and is also reachable as a hosted Streamable HTTP endpoint with a free anonymous token.",
+  "homepage_url": "https://mcp.zovo.one/s/spreadsheet",
+  "repository_url": "https://github.com/theluckystrike/mcp-spreadsheet",
+  "package_url": "https://mcp.zovo.one/mcp/spreadsheet",
+  "transports": [
+    "stdio",
+    "streamable-http"
+  ],
+  "tools": [
+    "sheet_info",
+    "sheet_read",
+    "sheet_query",
+    "sheet_stats",
+    "sheet_find",
+    "sheet_write",
+    "sheet_add_column"
+  ],
+  "license": "MIT",
+  "provider": {
+    "name": "theluckystrike",
+    "url": "https://mcp.zovo.one"
+  },
+  "status": "active"
+}


### PR DESCRIPTION
Adds `servers/files/zovo-spreadsheet/server.json`, one server, and commits the regenerated `README.md`.

**Checks run, as CONTRIBUTING requires:**

```
node scripts/validate-catalog.mjs   ->  Validated 23 MCP server entries.
node scripts/generate-readme.mjs    ->  Generated README.md with 9 populated categories.
```

The README diff is 6 added lines and nothing else.

**What it is.** Open, inspect, filter, edit and convert `.xlsx` and `.csv` files. Seven tools: `sheet_info`, `sheet_read`, `sheet_query`, and four write and convert tools. Source is MIT at https://github.com/theluckystrike/mcp-spreadsheet and it is published in the official MCP registry as `io.github.theluckystrike/excel-spreadsheet-xlsx-csv`.

**Category.** `files`, on the "document extraction" side of that category rather than `data`, because it reads a file you already have rather than connecting to a store.

**Verifiable before you merge.** The hosted endpoint answers discovery with no credential:

```
curl -s -X POST https://mcp.zovo.one/mcp/spreadsheet \
  -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' \
  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
```

Only `tools/call` needs a token, and `curl https://mcp.zovo.one/mcp/token` issues a free anonymous one with no account, no card and no email. The stdio path needs nothing hosted at all: the `.mcpb` bundle on the release runs locally.

**Disclosure.** I am the author.
